### PR TITLE
Use $http_host in nginx config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ server {
         try_files $uri @ppm;
     }
     location @ppm {
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
$host does not include the :port, whereas $http_host does. This broke a thing of mine not running on the default HTTP port that depended on HTTP_HOST until I made this change.